### PR TITLE
add support for specifying alternate cvmfs-config package to install via $INPUT_CVMFS_CONFIG_PACKAGE

### DIFF
--- a/.github/workflows/cvmfs_config_package.yml
+++ b/.github/workflows/cvmfs_config_package.yml
@@ -1,0 +1,13 @@
+name: Test setup-cvmfs action (with cvmfs_config_package)
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@main
+      with:
+        cvmfs_repositories: 'pilot.eessi-hpc.org'
+        cvmfs_config_package: 'https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi_0.2.3_all.deb'
+    - name: Setup CernVM-FS
+      run: cat /etc/cvmfs/default.local && ls /cvmfs/pilot.eessi-hpc.org && cvmfs_config showconfig pilot.eessi-hpc.org

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ jobs:
 The following parameters are supported:
 - `cvmfs_repositories` (optional, defaults to `atlas.cern.ch,atlas-condb.cern.ch,grid.cern.ch`): the list of repositories to load.
 - `cvmfs_http_proxy` (optional, defaults to `DIRECT`): the http proxy to use with cvmfs.
+- `cvmfs_config_package` (optional, defaults to `cvmfs-config-default`): URL to cvmfs config package to install
 
 ## Minimal Example
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Proxy for cvmfs repositories'
     required: false
     default: 'DIRECT'
+  cvmfs_config_package:
+    description: 'URL of cvmfs config package to install'
+    required: false
+    default: 'cvmfs-config-default'
 runs:
   using: "composite"
   steps: 

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -4,7 +4,7 @@
 wget -q https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
 sudo dpkg -i cvmfs-release-latest_all.deb
 sudo apt-get -q update
-sudo apt-get -q -y install cvmfs cvmfs-config-default
+sudo apt-get -q -y install cvmfs ${INPUT_CVMFS_CONFIG_PACKAGE:-cvmfs-config-default}
 rm -f cvmfs-release-latest_all.deb
 
 # Setup default.local


### PR DESCRIPTION
@wdconinc I didn't test this, but I expect this to work since it's very similar to the other `${INPUT_CVMFS...}` input variables.

This should allow use to install our own `cvmfs-config-eessi` package (see https://github.com/EESSI/filesystem-layer/releases).