### PR TITLE
[inputs] https://github.com/actions/runner/issues/665

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,3 +17,6 @@ runs:
   steps: 
     - run: ${{ github.action_path }}/setup-cvmfs.sh
       shell: bash
+      env:
+        INPUT_CVMFS_REPOSITORIES: ${{ inputs.cvmfs_repositories }}
+        INPUT_CVMFS_HTTP_PROXY: ${{ inputs.cvmfs_http_proxy }}


### PR DESCRIPTION
This should resolve the issue of inputs not being passed along to the setup script.

Residual issue: the checks here still use the main version of the action, so this won't be active until merged.