### PR TITLE
[cvfms_http_proxy] for auto proxy, do not try to access site

### DIFF
--- a/.github/workflows/cvmfs_http_proxy.yml
+++ b/.github/workflows/cvmfs_http_proxy.yml
@@ -9,4 +9,4 @@ jobs:
       with:
         cvmfs_http_proxy: 'auto'
     - name: Setup CernVM-FS
-      run: cat /etc/cvmfs/default.local && ls /cvmfs/grid.cern.ch/ && cvmfs_config showconfig grid.cern.ch
+      run: cat /etc/cvmfs/default.local


### PR DESCRIPTION
Setting cvmfs_http_proxy to anything other than DIRECT results in no access, so don't try to read any /cvmfs dirs.