### PR TITLE
Add more options and macOS support

### DIFF
--- a/.github/workflows/cvmfs_config_package.yml
+++ b/.github/workflows/cvmfs_config_package.yml
@@ -4,18 +4,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_repositories: 'pilot.eessi-hpc.org'
         cvmfs_http_proxy: 'DIRECT'
         cvmfs_config_package: 'https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi_0.2.3_all.deb'
-    - name: Setup CernVM-FS
+        run_local_checkout: 'true'
+    - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"
         cat /etc/cvmfs/default.local
+        echo "### Try cvmfs_config probe ###"
+        sudo cvmfs_config probe
         echo "### Test /cvmfs/pilot.eessi-hpc.org ###"
         ls /cvmfs/pilot.eessi-hpc.org
         echo "### Test cvmfs_config showconfig pilot.eessi-hpc.org ###"
         cvmfs_config showconfig pilot.eessi-hpc.org
-        echo "### Try cvmfs_config probe ###"
-        sudo cvmfs_config probe

--- a/.github/workflows/cvmfs_config_package.yml
+++ b/.github/workflows/cvmfs_config_package.yml
@@ -1,13 +1,21 @@
-name: Test setup-cvmfs action (with cvmfs_config_package)
+name: with cvmfs_config_package
 on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_repositories: 'pilot.eessi-hpc.org'
+        cvmfs_http_proxy: 'DIRECT'
         cvmfs_config_package: 'https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi_0.2.3_all.deb'
     - name: Setup CernVM-FS
-      run: cat /etc/cvmfs/default.local && ls /cvmfs/pilot.eessi-hpc.org && cvmfs_config showconfig pilot.eessi-hpc.org
+      run: |
+        echo "### Dump default.local ###"
+        cat /etc/cvmfs/default.local
+        echo "### Test /cvmfs/pilot.eessi-hpc.org ###"
+        ls /cvmfs/pilot.eessi-hpc.org
+        echo "### Test cvmfs_config showconfig pilot.eessi-hpc.org ###"
+        cvmfs_config showconfig pilot.eessi-hpc.org
+        echo "### Try cvmfs_config probe ###"
+        sudo cvmfs_config probe

--- a/.github/workflows/cvmfs_http_proxy.yml
+++ b/.github/workflows/cvmfs_http_proxy.yml
@@ -1,12 +1,15 @@
-name: Test setup-cvmfs action (with cvmfs_http_proxy)
+name: with cvmfs_http_proxy
 on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_http_proxy: 'auto'
     - name: Setup CernVM-FS
-      run: cat /etc/cvmfs/default.local
+      run: |
+        echo "### Dump default.local ###"
+        cat /etc/cvmfs/default.local
+        echo "### Chech cvmfs_http_proxy is set corretly to auto ###"
+        grep auto /etc/cvmfs/default.local

--- a/.github/workflows/cvmfs_http_proxy.yml
+++ b/.github/workflows/cvmfs_http_proxy.yml
@@ -4,9 +4,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_http_proxy: 'auto'
+        run_local_checkout: 'true'
     - name: Setup CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/.github/workflows/cvmfs_repositories.yml
+++ b/.github/workflows/cvmfs_repositories.yml
@@ -4,9 +4,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_repositories: 'grid.cern.ch'
+        run_local_checkout: 'true'
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/.github/workflows/cvmfs_repositories.yml
+++ b/.github/workflows/cvmfs_repositories.yml
@@ -1,12 +1,19 @@
-name: Test setup-cvmfs action (with cvmfs_repositories)
+name: with cvmfs_repositories
 on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_repositories: 'grid.cern.ch'
-    - name: Setup CernVM-FS
-      run: cat /etc/cvmfs/default.local && ls /cvmfs/grid.cern.ch/ && cvmfs_config showconfig grid.cern.ch
+    - name: Test CernVM-FS
+      run: |
+        echo "### Dump default.local ###"
+        cat /etc/cvmfs/default.local
+        echo "### Check if grid.cern.ch is in default.local ###"
+        grep grid.cern.ch /etc/cvmfs/default.local
+        echo "### Try to ls on /cvmfs/grid.cern.ch/ ###"
+        ls /cvmfs/grid.cern.ch/
+        echo "### Try cvmfs_config probe ###"
+        sudo cvmfs_config probe

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,15 @@
+name: macOS with cvmfs_repositories
+on: [push, pull_request]
+jobs:
+  macOS-minimal:
+    runs-on: macos-latest
+    steps:
+    - uses: cvmfs-contrib/github-action-cvmfs@main
+      with:
+        cvmfs_repositories: 'sft.cern.ch'
+    - name: Test CernVM-FS
+      run: |
+       echo "### Dump default.local ###"
+       cat /etc/cvmfs/default.local
+       echo "### Try to ls on /Users/Shared/cvmfs/sft.cern.ch/ ###"
+       ls /Users/Shared/cvmfs/sft.cern.ch/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,9 +4,11 @@ jobs:
   macOS-minimal:
     runs-on: macos-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_repositories: 'sft.cern.ch'
+        run_local_checkout: 'true'
     - name: Test CernVM-FS
       run: |
        echo "### Dump default.local ###"

--- a/.github/workflows/minimal-usage.yml
+++ b/.github/workflows/minimal-usage.yml
@@ -1,10 +1,21 @@
-name: Test setup-cvmfs action (minimal usage)
+name: Minimal usage
 on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
-    - name: Setup CernVM-FS
-      run: cat /etc/cvmfs/default.local && ls /cvmfs/grid.cern.ch/ && cvmfs_config showconfig grid.cern.ch
+    - name: Test CernVM-FS
+      run: |
+        echo "### Dump default.local ###"
+        cat /etc/cvmfs/default.local
+        echo "### Test /cvmfs/lhcb.cern.ch ###"
+        ls /cvmfs/lhcb.cern.ch
+        echo "### Test /cvmfs/auger.egi.eu ###"
+        ls /cvmfs/auger.egi.eu
+        echo "### Test /cvmfs/dune.opensciencegrid.org ###"
+        ls /cvmfs/dune.opensciencegrid.org
+        echo "### Test /cvmfs/sw.hsf.org ###"
+        ls /cvmfs/sw.hsf.org
+        echo "### Test /cvmfs/sft.cern.ch ###"
+        ls /cvmfs/sft.cern.ch

--- a/.github/workflows/minimal-usage.yml
+++ b/.github/workflows/minimal-usage.yml
@@ -4,7 +4,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@main
+      with:
+        run_local_checkout: 'true'
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/README.md
+++ b/README.md
@@ -4,46 +4,151 @@ This GitHub Action sets up CernVM-FS for use in GitHub Workflows.
 ## Instructions
 You can use this GitHub Action in a workflow in your own repository by with `uses: cvmfs-contrib/github-action-cvmfs@main`.
 
-For example, the file `.github/workflows/tests.yml` could include the following stanza:
+A minimal job examples for the GitHub-hosted runners of type `ubuntu-latest`:
 ```yaml
 jobs:
-  build:
+  ubuntu-minimal:
     runs-on: ubuntu-latest
     steps:
-    - uses: cvmfs-contrib/github-action-cvmfs@main
+    - uses: AIDASoft/setup-cvmfs@master
+    - name: Test CernVM-FS
+      run: ls /cvmfs/sft.cern.ch/
 ```
+By default 	`*.cern.ch, *.egi.eu, *.opensciencegrid.org *.hsf.org` repositories are available
+
+The Action also works with the runners of type `macos-latest`, however in this case it is necessary to specify which repositories you want to mount (via the variable `cvmfs_repositories`), as there is not auto mount for masOS. A minimal example of usage on `macos-latest` is:
+```yaml
+jobs:
+  macOS-minimal:
+    runs-on: macos-latest
+    steps:
+    - uses: AIDASoft/setup-cvmfs@master
+      with:
+        cvmfs_repositories: 'sft.cern.ch'
+    - name: Test CernVM-FS
+      run: ls /Users/Shared/cvmfs/sft.cern.ch/
+```
+Beware that because the runner cannot be rebooted in the macOS case and the repositories are mounted under `/Users/Shared/cvmfs/`
 
 ## Optional Parameters
 The following parameters are supported:
-- `cvmfs_repositories` (optional, defaults to `atlas.cern.ch,atlas-condb.cern.ch,grid.cern.ch`): the list of repositories to load.
-- `cvmfs_http_proxy` (optional, defaults to `DIRECT`): the http proxy to use with cvmfs.
-- `cvmfs_config_package` (optional, defaults to `cvmfs-config-default`): URL to cvmfs config package to install
+- `cvmfs_alien_cache`: If set, use an alien cache at the given location.
+- `cvmfs_alt_root_path`: If set to yes, use alternative root catalog path. Only required for fixed catalogs (tag / hash) under the alternative path.
+- `cvmfs_authz_helper`: Full path to an authz helper, overwrites the helper hint in the catalog.
+- `cvmfs_authz_search_path`: Full path to the directory that contains the authz helpers.
+- `cvmfs_auto_update`: If set to no, disables the automatic update of file catalogs.
+- `cvmfs_backoff_init`: Seconds for the maximum initial backoff when retrying to download data.
+- `cvmfs_backoff_max`: Maximum backoff in seconds when retrying to download data.
+- `cvmfs_cache_base`: Location (directory) of the CernVM-FS cache.
+- `cvmfs_catalog_watermark`: Try to release pinned catalogs when their number surpasses the given watermark. Defaults to 1/4 CVMFS_NFILES; explicitly set by shrinkwrap.
+- `cvmfs_check_permissions`: If set to no, disable checking of file ownership and permissions (open all files).
+- `cvmfs_claim_ownership`: If set to yes, allows CernVM-FS to claim ownership of files and directories.
+- `cvmfs_client_profile`: Choose a suitable proxy automatically is set to single.
+- `cvmfs_config_repo_required`: If set to yes, no repository can be mounted unless the config repository is available.
+- `cvmfs_debuglog`: If set, run CernVM-FS in debug mode and write a verbose log the the specified file.
+- `cvmfs_default_domain`: The default domain will be automatically appended to repository names when given without a domain.
+- `cvmfs_dns_max_ttl`: Maximum effective TTL in seconds for DNS queries of proxy server names(not Stratum 1s). Defaults to 1 day.
+- `cvmfs_dns_min_ttl`: Minimum effective TTL in seconds for DNS queries of proxy server names (not Stratum 1s). Defaults to 1 minute.
+- `cvmfs_dns_retries`: Number of retries when resolving proxy names.
+- `cvmfs_dns_roaming`: If true, watch /etc/resolv.conf for nameserver changes.
+- `cvmfs_dns_timeout`: Timeout in seconds when resolving proxy names.
+- `cvmfs_enforce_acls`: Enforce POSIX ACLs stored in the repository. Requires libfuse 3.
+- `cvmfs_external_fallback_proxy`: List of HTTP proxies similar to CVMFS_EXTERNAL_HTTP_PROXY. The fallback proxies are added to the end of the normal proxies, and disable DIRECT connections.
+- `cvmfs_external_http_proxy`: Chain of HTTP proxy groups to be used when CernVM-FS is accessing external data.
+- `cvmfs_external_timeout`: Timeout in seconds for HTTP requests to an external-data server with a proxy server.
+- `cvmfs_external_timeout_direct`: Timeout in seconds for HTTP requests to an external-data server without a proxy server.
+- `cvmfs_external_url`: Semicolon-separated chain of webservers serving external data chunks.
+- `cvmfs_fallback_proxy`: List of HTTP proxies similar to CVMFS_HTTP_PROXY. The fallback proxies are added to the end of the normal proxies, and disable DIRECT connections.
+- `cvmfs_follow_redirects`: When set to yes, follow up to 4 HTTP redirects in requests.
+- `cvmfs_hide_magic_xattrs`: If set to yes the client will not expose CernVM-FS specific extended attributes.
+- `cvmfs_host_reset_after`: See CVMFS_PROXY_RESET_AFTER.
+- `cvmfs_http_proxy`: Chain of HTTP proxy groups used by CernVM-FS. Necessary.Set to DIRECT if you don’t use proxies.
+- `cvmfs_ignore_signature`: When set to yes, don’t verify CernVM-FS file catalog signatures.
+- `cvmfs_initial_generation`: Initial inode generation. Used for testing.
+- `cvmfs_instrument_fuse`: When set to true gather performance statistics about the FUSE callbacks. The results are displayed with cvmfs_talk internal affairs.
+- `cvmfs_ipfamily_prefer`: Which IP protocol to prefer when connecting to proxies. Can be either 4 or 6.
+- `cvmfs_kcache_timeout`: Timeout for path names and file attributes in the kernel file system buffers.
+- `cvmfs_keys_dir`: Directory containing *.pub files used as repository signing keys. If set, this parameter has precedence over CVMFS_PUBLIC_KEY.
+- `cvmfs_low_speed_limit`: Minimum transfer rate a server or proxy must provide.
+- `cvmfs_max_external_servers`: Limit the number of (geo sorted) stratum 1 servers for external data that are effectively used.
+- `cvmfs_max_ipaddr_per_proxy`: Limit the number of IP addresses a proxy names resolves into. From all registered addresses, up to the limit are randomly selected.
+- `cvmfs_max_retries`: Maximum number of retries for a given proxy/host combination.
+- `cvmfs_max_servers`: Limit the number of (geo sorted) stratum 1 servers that are effectively used.
+- `cvmfs_max_ttl`: Maximum file catalog TTL in minutes. Can overwrite the TTL stored in the catalog.
+- `cvmfs_memcache_size`: Size of the CernVM-FS meta-data memory cache in Megabyte.
+- `cvmfs_mount_rw`: Mount CernVM-FS as a read/write file system. Write operations will fail but this option can workaround faulty open() flags.
+- `cvmfs_nfiles`: Maximum number of open file descriptors that can be used by the CernVM-FS process.
+- `cvmfs_nfs_interleaved_inodes`: In NFS mode, use only inodes of the form an+b, specified as “b%a”.
+- `cvmfs_nfs_shared`: If set a path, used to store the NFS maps in an SQlite database, instead of the usual LevelDB storage in the cache directory.
+- `cvmfs_nfs_source`: If set to yes, act as a source for the NFS daemon (NFS export).
+- `cvmfs_oom_score_adj`: Set the Linux kernel’s out-of-memory killer priority for the CernVM-FS client [-1000 - 1000].
+- `cvmfs_pac_urls`: Chain of URLs pointing to PAC files with HTTP proxy configuration information.
+- `cvmfs_proxy_reset_after`: Delay in seconds after which CernVM-FS will retry the primary proxy group in case of a fail-over to another group.
+- `cvmfs_proxy_template`: Overwrite the default proxy template in Geo-API calls. Only needed for debugging.
+- `cvmfs_public_key`: Colon-separated list of repository signing keys.
+- `cvmfs_quota_limit`: Soft-limit of the cache in Megabyte.
+- `cvmfs_reload_sockets`: Directory of the sockets used by the CernVM-FS loader to trigger hotpatching/reloading.
+- `cvmfs_repositories`: Comma-separated list of fully qualified repository names that shall be mountable under /cvmfs.
+- `cvmfs_repository_date`: A timestamp in ISO format (e.g. 2007-03-01T13:00:00Z). Selects the repository state as of the given date.
+- `cvmfs_repository_tag`: Select a named repository snapshot that should be mounted instead of trunk.
+- `cvmfs_root_hash`: Hash of the root file catalog, implies CVMFS_AUTO_UPDATE=no.
+- `cvmfs_send_info_header`: If set to yes, include the cvmfs path of downloaded data in HTTP headers.
+- `cvmfs_server_cache_mode`: Enable special cache semantics for a client used as a publisher’s repository base line.
+- `cvmfs_server_url`: Semicolon-separated chain of Stratum~1 servers.
+- `cvmfs_shared_cache`: If set to no, makes a repository use an exclusive cache.
+- `cvmfs_strict_mount`: If set to yes, mount only repositories that are listed in CVMFS_REPOSITORIES.
+- `cvmfs_suid`: If set to yes, enable suid magic on the mounted repository. Requires mounting as root.
+- `cvmfs_syslog_facility`: If set to a number between 0 and 7, uses the corresponding LOCAL$n$ facility for syslog messages.
+- `cvmfs_syslog_level`: If set to 1 or 2, sets the syslog level for CernVM-FS messages to LOG_DEBUG or LOG_INFO respectively.
+- `cvmfs_systemd_nokill`: If set to yes, modify the command line to `@vmfs2` ... in order to act as a systemd lowlevel storage manager.
+- `cvmfs_timeout`: Timeout in seconds for HTTP requests with a proxy server.
+- `cvmfs_timeout_direct`: Timeout in seconds for HTTP requests without a proxy server.
+- `cvmfs_tracefile`: If set, enables the tracer and trace file system calls to the given file.
+- `cvmfs_use_cdn`: Change the stratum 1 endpoints to caching servers from Cloudflare.
+- `cvmfs_use_geoapi`: Request order of Stratum 1 servers and fallback proxies via Geo-API.
+- `cvmfs_user`: Sets the gid and uid mount options. Don’t touch or overwrite.
+- `cvmfs_usyslog`: All messages that normally are logged to syslog are re-directed to the given file. This file can grow up to 500kB and there is one step of log rotation. Required for $mu$CernVM.
+- `cvmfs_workspace`: Set the local directory for storing special files (defaults to the cache directory).
+- `cvmfs_ubuntu_deb_location`: Location from where to download the Ubuntu deb package of CernVM-FS.
+- `cvmfs_macos_pkg_location`: Location from where to download the masOS pkg package of CernVM-FS.
+- `cvmfs_config_package`: URL to the cvmfs config package to install.
+
+# Optional Parameters Defaults
+All optional parameters are set to default to `''`(empty string). All variables that are set to this value are not propagated to `default.local`. The only exception to this are the following variables set to particular defaults:
+ - `cvmfs_quota_limit`: `'15000'` (see [GitHub Runner Hardware](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources) before changing)
+ - `cvmfs_client_profile`: `'single'`
+ - `cvmfs_use_cdn`: `'yes'`
+ - `cvmfs_ubuntu_deb_location`: `https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb`
+ - `cvmfs_macos_pkg_location`: `http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-latest.pkg`
+ - `cvmfs_config_package`: `cvmfs-config-default`
 
 ## Minimal Example
 
-The following minimal example, which is also a workflow in this repository at [.github/workflows/minimal-usage.yml](https://github.com/cvmfs-contrib/github-action-cvmfs/tree/main/.github/workflows/minimal-usage.yml), setups up CernVM-FS and lists the contents of the `/cvmfs/grid.cern.ch` directory.
+The following minimal example, which is also a workflow in this repository at [.github/workflows/minimal-usage.yml](https://github.com/cvmfs-contrib/github-action-cvmfs/tree/main/.github/workflows/minimal-usage.yml), setups up CernVM-FS and lists the contents of the selected repositories from `*.cern.ch, *.egi.eu, *.opensciencegrid.org *.hsf.org`.
 ```yaml
-name: Test setup-cvmfs action
+name: Minimal usage
 on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@main
-    - name: Setup CernVM-FS
-      run: cat /etc/cvmfs/default.local && ls /cvmfs/grid.cern.ch && cvmfs_config showconfig grid.cern.ch
+    - uses: petricm/github-action-cvmfs@add
+    - name: Test CernVM-FS
+      run: |
+        ls /cvmfs/lhcb.cern.ch
+        ls /cvmfs/auger.egi.eu
+        ls /cvmfs/dune.opensciencegrid.org
+        ls /cvmfs/sw.hsf.org
+        ls /cvmfs/sft.cern.ch
 ```
 
 ## What Does This Action Do?
 
-This GitHub Action installs the [CernVM-FS debian package](https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb), and configures it with the `CVMFS_REPOSITORIES` and `CVMFS_HTTP_PROXY` settings optionally specified as arguments. It configures autofs to automatically mount the cvmfs repositories that are accessed.
-
-To avoid any overhead on the CernVM-FS stratum 1 servers that you are accessing, this GitHub Action uses the [OpenHTC](https://openhtc.io) caching edge servers.
+This GitHub Action installs the [CernVM-FS package](https://cernvm.cern.ch/fs/#download), and configures it with the  `CVMFS_CLIENT_PROFILE='signle'` and `CVMFS_USE_CDN='yes'` to avoid any overhead on the CernVM-FS stratum 1 servers that you are accessing, this GitHub Action uses the [OpenHTC](https://openhtc.io) caching edge servers.
 
 ## Limitations
 
-This GitHub Action is only expected to work in workflows that [run on](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on) ubuntu targets (and even then likely only `ubuntu-latest`). This exludes the `macos` and `windows` targets.
+This GitHub Action is only expected to work in workflows that [run on](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on) ubuntu nad macOS targets (and even then likely only `ubuntu-latest`). This exludes the `windows` targets.
 
 ## Use With Docker
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ jobs:
   ubuntu-minimal:
     runs-on: ubuntu-latest
     steps:
-    - uses: AIDASoft/setup-cvmfs@master
+    - uses: cvmfs-contrib/github-action-cvmfs@main
     - name: Test CernVM-FS
       run: ls /cvmfs/sft.cern.ch/
 ```
@@ -22,7 +22,7 @@ jobs:
   macOS-minimal:
     runs-on: macos-latest
     steps:
-    - uses: AIDASoft/setup-cvmfs@master
+    - uses: cvmfs-contrib/github-action-cvmfs@main
       with:
         cvmfs_repositories: 'sft.cern.ch'
     - name: Test CernVM-FS
@@ -112,6 +112,7 @@ The following parameters are supported:
 - `cvmfs_ubuntu_deb_location`: Location from where to download the Ubuntu deb package of CernVM-FS.
 - `cvmfs_macos_pkg_location`: Location from where to download the masOS pkg package of CernVM-FS.
 - `cvmfs_config_package`: URL to the cvmfs config package to install.
+- `run_local_checkout`: Run the local checkout of the action and not the main repo code. Only used for testing and development of this action (needed in CI).
 
 # Optional Parameters Defaults
 All optional parameters are set to default to `''`(empty string). All variables that are set to this value are not propagated to `default.local`. The only exception to this are the following variables set to particular defaults:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'CernVM-FS'
+name: 'CernVM File System (cvmfs)'
 description: 'Install the CernVM File System that provides a scalable, reliable and low-maintenance software distribution service.'
 branding:
   icon: 'folder'

--- a/action.yml
+++ b/action.yml
@@ -1,27 +1,413 @@
-name: 'CernVM-FS (cvmfs)'
-description: 'Load the CernVM-FS filesystem at /cvmfs'
+name: 'CernVM-FS'
+description: 'Install the CernVM File System that provides a scalable, reliable and low-maintenance software distribution service.'
 branding:
-  icon: 'database'
-  color: 'blue'
+  icon: 'folder'
+  color: 'orange'
 inputs:
-  cvmfs_repositories:
-    description: 'List of cvmfs repositories to load'
-    required: false
-    default: 'atlas.cern.ch,atlas-condb.cern.ch,grid.cern.ch'
-  cvmfs_http_proxy:
-    description: 'Proxy for cvmfs repositories'
-    required: false
-    default: 'DIRECT'
-  cvmfs_config_package:
-    description: 'URL of cvmfs config package to install'
+  cvmfs_alien_cache:
+    description: 'If set, use an alien cache at the given location.'
     required: false
     default: ''
+  cvmfs_alt_root_path:
+    description: 'If set to yes, use alternative root catalog path. Only required for fixed catalogs (tag / hash) under the alternative path.'
+    required: false
+    default: ''
+  cvmfs_authz_helper:
+    description: 'Full path to an authz helper, overwrites the helper hint in the catalog.'
+    required: false
+    default: ''
+  cvmfs_authz_search_path:
+    description: 'Full path to the directory that contains the authz helpers.'
+    required: false
+    default: ''
+  cvmfs_auto_update:
+    description: 'If set to no, disables the automatic update of file catalogs.'
+    required: false
+    default: ''
+  cvmfs_backoff_init:
+    description: 'Seconds for the maximum initial backoff when retrying to download data.'
+    required: false
+    default: ''
+  cvmfs_backoff_max:
+    description: 'Maximum backoff in seconds when retrying to download data.'
+    required: false
+    default: ''
+  cvmfs_cache_base:
+    description: 'Location (directory) of the CernVM-FS cache.'
+    required: false
+    default: ''
+  cvmfs_catalog_watermark:
+    description: 'Try to release pinned catalogs when their number surpasses the given watermark. Defaults to 1/4 CVMFS_NFILES; explicitly set by shrinkwrap.'
+    required: false
+    default: ''
+  cvmfs_check_permissions:
+    description: 'If set to no, disable checking of file ownership and permissions (open all files).'
+    required: false
+    default: ''
+  cvmfs_claim_ownership:
+    description: 'If set to yes, allows CernVM-FS to claim ownership of files and directories.'
+    required: false
+    default: ''
+  cvmfs_client_profile:
+    description: 'Choose a suitable proxy automatically is set to single'
+    required: false
+    default: 'single'
+  cvmfs_config_repo_required:
+    description: 'If set to yes, no repository can be mounted unless the config repository is available.'
+    required: false
+    default: ''
+  cvmfs_debuglog:
+    description: 'If set, run CernVM-FS in debug mode and write a verbose log the the specified file.'
+    required: false
+    default: ''
+  cvmfs_default_domain:
+    description: 'The default domain will be automatically appended to repository names when given without a domain.'
+    required: false
+    default: ''
+  cvmfs_dns_max_ttl:
+    description: 'Maximum effective TTL in seconds for DNS queries of proxy server names(not Stratum 1s). Defaults to 1 day.'
+    required: false
+    default: ''
+  cvmfs_dns_min_ttl:
+    description: 'Minimum effective TTL in seconds for DNS queries of proxy server names (not Stratum 1s). Defaults to 1 minute.'
+    required: false
+    default: ''
+  cvmfs_dns_retries:
+    description: 'Number of retries when resolving proxy names.'
+    required: false
+    default: ''
+  cvmfs_dns_roaming:
+    description: 'If true, watch /etc/resolv.conf for nameserver changes.'
+    required: false
+    default: ''
+  cvmfs_dns_timeout:
+    description: 'Timeout in seconds when resolving proxy names.'
+    required: false
+    default: ''
+  cvmfs_enforce_acls:
+    description: 'Enforce POSIX ACLs stored in the repository. Requires libfuse 3.'
+    required: false
+    default: ''
+  cvmfs_external_fallback_proxy:
+    description: 'List of HTTP proxies similar to CVMFS_EXTERNAL_HTTP_PROXY. The fallback proxies are added to the end of the normal proxies, and disable DIRECT connections.'
+    required: false
+    default: ''
+  cvmfs_external_http_proxy:
+    description: 'Chain of HTTP proxy groups to be used when CernVM-FS is accessing external data.'
+    required: false
+    default: ''
+  cvmfs_external_timeout:
+    description: 'Timeout in seconds for HTTP requests to an external-data server with a proxy server.'
+    required: false
+    default: ''
+  cvmfs_external_timeout_direct:
+    description: 'Timeout in seconds for HTTP requests to an external-data server without a proxy server.'
+    required: false
+    default: ''
+  cvmfs_external_url:
+    description: 'Semicolon-separated chain of webservers serving external data chunks.'
+    required: false
+    default: ''
+  cvmfs_fallback_proxy:
+    description: 'List of HTTP proxies similar to CVMFS_HTTP_PROXY. The fallback proxies are added to the end of the normal proxies, and disable DIRECT connections.'
+    required: false
+    default: ''
+  cvmfs_follow_redirects:
+    description: 'When set to yes, follow up to 4 HTTP redirects in requests.'
+    required: false
+    default: ''
+  cvmfs_hide_magic_xattrs:
+    description: 'If set to yes the client will not expose CernVM-FS specific extended attributes.'
+    required: false
+    default: ''
+  cvmfs_host_reset_after:
+    description: 'See CVMFS_PROXY_RESET_AFTER.'
+    required: false
+    default: ''
+  cvmfs_http_proxy:
+    description: 'Chain of HTTP proxy groups used by CernVM-FS. Necessary.Set to DIRECT if you don’t use proxies.'
+    required: false
+    default: ''
+  cvmfs_ignore_signature:
+    description: 'When set to yes, don’t verify CernVM-FS file catalog signatures.'
+    required: false
+    default: ''
+  cvmfs_initial_generation:
+    description: 'Initial inode generation. Used for testing.'
+    required: false
+    default: ''
+  cvmfs_instrument_fuse:
+    description: 'When set to true gather performance statistics about the FUSE callbacks. The results are displayed with cvmfs_talk internal affairs.'
+    required: false
+    default: ''
+  cvmfs_ipfamily_prefer:
+    description: 'Which IP protocol to prefer when connecting to proxies. Can be either 4 or 6.'
+    required: false
+    default: ''
+  cvmfs_kcache_timeout:
+    description: 'Timeout for path names and file attributes in the kernel file system buffers.'
+    required: false
+    default: ''
+  cvmfs_keys_dir:
+    description: 'Directory containing *.pub files used as repository signing keys. If set, this parameter has precedence over CVMFS_PUBLIC_KEY.'
+    required: false
+    default: ''
+  cvmfs_low_speed_limit:
+    description: 'Minimum transfer rate a server or proxy must provide.'
+    required: false
+    default: ''
+  cvmfs_max_external_servers:
+    description: 'Limit the number of (geo sorted) stratum 1 servers for external data that are effectively used.'
+    required: false
+    default: ''
+  cvmfs_max_ipaddr_per_proxy:
+    description: 'Limit the number of IP addresses a proxy names resolves into. From all registered addresses, up to the limit are randomly selected.'
+    required: false
+    default: ''
+  cvmfs_max_retries:
+    description: 'Maximum number of retries for a given proxy/host combination.'
+    required: false
+    default: ''
+  cvmfs_max_servers:
+    description: 'Limit the number of (geo sorted) stratum 1 servers that are effectively used.'
+    required: false
+    default: ''
+  cvmfs_max_ttl:
+    description: 'Maximum file catalog TTL in minutes. Can overwrite the TTL stored in the catalog.'
+    required: false
+    default: ''
+  cvmfs_memcache_size:
+    description: 'Size of the CernVM-FS meta-data memory cache in Megabyte.'
+    required: false
+    default: ''
+  cvmfs_mount_rw:
+    description: 'Mount CernVM-FS as a read/write file system. Write operations will fail but this option can workaround faulty open() flags.'
+    required: false
+    default: ''
+  cvmfs_nfiles:
+    description: 'Maximum number of open file descriptors that can be used by the CernVM-FS process.'
+    required: false
+    default: ''
+  cvmfs_nfs_interleaved_inodes:
+    description: 'In NFS mode, use only inodes of the form an+b, specified as “b%a”.'
+    required: false
+    default: ''
+  cvmfs_nfs_shared:
+    description: 'If set a path, used to store the NFS maps in an SQlite database, instead of the usual LevelDB storage in the cache directory.'
+    required: false
+    default: ''
+  cvmfs_nfs_source:
+    description: 'If set to yes, act as a source for the NFS daemon (NFS export).'
+    required: false
+    default: ''
+  cvmfs_oom_score_adj:
+    description: 'Set the Linux kernel’s out-of-memory killer priority for the CernVM-FS client [-1000 - 1000].'
+    required: false
+    default: ''
+  cvmfs_pac_urls:
+    description: 'Chain of URLs pointing to PAC files with HTTP proxy configuration information.'
+    required: false
+    default: ''
+  cvmfs_proxy_reset_after:
+    description: 'Delay in seconds after which CernVM-FS will retry the primary proxy group in case of a fail-over to another group.'
+    required: false
+    default: ''
+  cvmfs_proxy_template:
+    description: 'Overwrite the default proxy template in Geo-API calls. Only needed for debugging.'
+    required: false
+    default: ''
+  cvmfs_public_key:
+    description: 'Colon-separated list of repository signing keys.'
+    required: false
+    default: ''
+  cvmfs_quota_limit:
+    description: 'Soft-limit of the cache in Megabyte. Consult https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources before changing'
+    required: false
+    default: '15000'
+  cvmfs_reload_sockets:
+    description: 'Directory of the sockets used by the CernVM-FS loader to trigger hotpatching/reloading.'
+    required: false
+    default: ''
+  cvmfs_repositories:
+    description: 'Comma-separated list of fully qualified repository names that shall be mountable under /cvmfs.'
+    required: false
+    default: ''
+  cvmfs_repository_date:
+    description: 'A timestamp in ISO format (e.g. 2007-03-01T13:00:00Z). Selects the repository state as of the given date.'
+    required: false
+    default: ''
+  cvmfs_repository_tag:
+    description: 'Select a named repository snapshot that should be mounted instead of trunk.'
+    required: false
+    default: ''
+  cvmfs_root_hash:
+    description: 'Hash of the root file catalog, implies CVMFS_AUTO_UPDATE=no.'
+    required: false
+    default: ''
+  cvmfs_send_info_header:
+    description: 'If set to yes, include the cvmfs path of downloaded data in HTTP headers.'
+    required: false
+    default: ''
+  cvmfs_server_cache_mode:
+    description: 'Enable special cache semantics for a client used as a publisher’s repository base line.'
+    required: false
+    default: ''
+  cvmfs_server_url:
+    description: 'Semicolon-separated chain of Stratum~1 servers.'
+    required: false
+    default: ''
+  cvmfs_shared_cache:
+    description: 'If set to no, makes a repository use an exclusive cache.'
+    required: false
+    default: ''
+  cvmfs_strict_mount:
+    description: 'If set to yes, mount only repositories that are listed in CVMFS_REPOSITORIES.'
+    required: false
+    default: ''
+  cvmfs_suid:
+    description: 'If set to yes, enable suid magic on the mounted repository. Requires mounting as root.'
+    required: false
+    default: ''
+  cvmfs_syslog_facility:
+    description: 'If set to a number between 0 and 7, uses the corresponding LOCAL$n$ facility for syslog messages.'
+    required: false
+    default: ''
+  cvmfs_syslog_level:
+    description: 'If set to 1 or 2, sets the syslog level for CernVM-FS messages to LOG_DEBUG or LOG_INFO respectively.'
+    required: false
+    default: ''
+  cvmfs_systemd_nokill:
+    description: 'If set to yes, modify the command line to @vmfs2 ... in order to act as a systemd lowlevel storage manager.'
+    required: false
+    default: ''
+  cvmfs_timeout:
+    description: 'Timeout in seconds for HTTP requests with a proxy server.'
+    required: false
+    default: ''
+  cvmfs_timeout_direct:
+    description: 'Timeout in seconds for HTTP requests without a proxy server.'
+    required: false
+    default: ''
+  cvmfs_tracefile:
+    description: 'If set, enables the tracer and trace file system calls to the given file.'
+    required: false
+    default: ''
+  cvmfs_use_cdn:
+    description: 'Change the stratum 1 endpoints to caching servers from Cloudflare.'
+    required: false
+    default: 'yes'
+  cvmfs_use_geoapi:
+    description: 'Request order of Stratum 1 servers and fallback proxies via Geo-API.'
+    required: false
+    default: ''
+  cvmfs_user:
+    description: 'Sets the gid and uid mount options. Don’t touch or overwrite.'
+    required: false
+    default: ''
+  cvmfs_usyslog:
+    description: 'All messages that normally are logged to syslog are re-directed to the given file. This file can grow up to 500kB and there is one step of log rotation. Required for $mu$CernVM.'
+    required: false
+    default: ''
+  cvmfs_workspace:
+    description: 'Set the local directory for storing special files (defaults to the cache directory).'
+    required: false
+    default: ''
+  cvmfs_ubuntu_deb_location:
+    description: 'Location from where to download the Ubuntu deb package of CernVM-FS'
+    required: false
+    default: 'https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb'
+  cvmfs_macos_pkg_location:
+    description: 'Location from where to download the masOS pkg package of CernVM-FS'
+    required: false
+    default: 'http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-latest.pkg'
+  cvmfs_config_package:
+    description: 'URL to the cvmfs config package to install'
+    required: false
+    default: 'cvmfs-config-default'
 runs:
   using: "composite"
-  steps: 
+  steps:
     - run: ${{ github.action_path }}/setup-cvmfs.sh
       shell: bash
       env:
-        INPUT_CVMFS_REPOSITORIES: ${{ inputs.cvmfs_repositories }}
-        INPUT_CVMFS_HTTP_PROXY: ${{ inputs.cvmfs_http_proxy }}
-        INPUT_CVMFS_CONFIG_PACKAGE: ${{ inputs.cvmfs_config_package }}
+        THIS: ${{ github.action_path }}
+        CVMFS_ALIEN_CACHE: ${{ inputs.cvmfs_alien_cache }}
+        CVMFS_ALT_ROOT_PATH: ${{ inputs.cvmfs_alt_root_path }}
+        CVMFS_AUTHZ_HELPER: ${{ inputs.cvmfs_authz_helper }}
+        CVMFS_AUTHZ_SEARCH_PATH: ${{ inputs.cvmfs_authz_search_path }}
+        CVMFS_AUTO_UPDATE: ${{ inputs.cvmfs_auto_update }}
+        CVMFS_BACKOFF_INIT: ${{ inputs.cvmfs_backoff_init }}
+        CVMFS_BACKOFF_MAX: ${{ inputs.cvmfs_backoff_max }}
+        CVMFS_CACHE_BASE: ${{ inputs.cvmfs_cache_base }}
+        CVMFS_CATALOG_WATERMARK: ${{ inputs.cvmfs_catalog_watermark }}
+        CVMFS_CHECK_PERMISSIONS: ${{ inputs.cvmfs_check_permissions }}
+        CVMFS_CLAIM_OWNERSHIP: ${{ inputs.cvmfs_claim_ownership }}
+        CVMFS_CLIENT_PROFILE: ${{ inputs.cvmfs_client_profile }}
+        CVMFS_CONFIG_REPO_REQUIRED: ${{ inputs.cvmfs_config_repo_required }}
+        CVMFS_DEBUGLOG: ${{ inputs.cvmfs_debuglog }}
+        CVMFS_DEFAULT_DOMAIN: ${{ inputs.cvmfs_default_domain }}
+        CVMFS_DNS_MAX_TTL: ${{ inputs.cvmfs_dns_max_ttl }}
+        CVMFS_DNS_MIN_TTL: ${{ inputs.cvmfs_dns_min_ttl }}
+        CVMFS_DNS_RETRIES: ${{ inputs.cvmfs_dns_retries }}
+        CVMFS_DNS_ROAMING: ${{ inputs.cvmfs_dns_roaming }}
+        CVMFS_DNS_TIMEOUT: ${{ inputs.cvmfs_dns_timeout }}
+        CVMFS_ENFORCE_ACLS: ${{ inputs.cvmfs_enforce_acls }}
+        CVMFS_EXTERNAL_FALLBACK_PROXY: ${{ inputs.cvmfs_external_fallback_proxy }}
+        CVMFS_EXTERNAL_HTTP_PROXY: ${{ inputs.cvmfs_external_http_proxy }}
+        CVMFS_EXTERNAL_TIMEOUT: ${{ inputs.cvmfs_external_timeout }}
+        CVMFS_EXTERNAL_TIMEOUT_DIRECT: ${{ inputs.cvmfs_external_timeout_direct }}
+        CVMFS_EXTERNAL_URL: ${{ inputs.cvmfs_external_url }}
+        CVMFS_FALLBACK_PROXY: ${{ inputs.cvmfs_fallback_proxy }}
+        CVMFS_FOLLOW_REDIRECTS: ${{ inputs.cvmfs_follow_redirects }}
+        CVMFS_HIDE_MAGIC_XATTRS: ${{ inputs.cvmfs_hide_magic_xattrs }}
+        CVMFS_HOST_RESET_AFTER: ${{ inputs.cvmfs_host_reset_after }}
+        CVMFS_HTTP_PROXY: ${{ inputs.cvmfs_http_proxy }}
+        CVMFS_IGNORE_SIGNATURE: ${{ inputs.cvmfs_ignore_signature }}
+        CVMFS_INITIAL_GENERATION: ${{ inputs.cvmfs_initial_generation }}
+        CVMFS_INSTRUMENT_FUSE: ${{ inputs.cvmfs_instrument_fuse }}
+        CVMFS_IPFAMILY_PREFER: ${{ inputs.cvmfs_ipfamily_prefer }}
+        CVMFS_KCACHE_TIMEOUT: ${{ inputs.cvmfs_kcache_timeout }}
+        CVMFS_KEYS_DIR: ${{ inputs.cvmfs_keys_dir }}
+        CVMFS_LOW_SPEED_LIMIT: ${{ inputs.cvmfs_low_speed_limit }}
+        CVMFS_MAX_EXTERNAL_SERVERS: ${{ inputs.cvmfs_max_external_servers }}
+        CVMFS_MAX_IPADDR_PER_PROXY: ${{ inputs.cvmfs_max_ipaddr_per_proxy }}
+        CVMFS_MAX_RETRIES: ${{ inputs.cvmfs_max_retries }}
+        CVMFS_MAX_SERVERS: ${{ inputs.cvmfs_max_servers }}
+        CVMFS_MAX_TTL: ${{ inputs.cvmfs_max_ttl }}
+        CVMFS_MEMCACHE_SIZE: ${{ inputs.cvmfs_memcache_size }}
+        CVMFS_MOUNT_RW: ${{ inputs.cvmfs_mount_rw }}
+        CVMFS_NFILES: ${{ inputs.cvmfs_nfiles }}
+        CVMFS_NFS_INTERLEAVED_INODES: ${{ inputs.cvmfs_nfs_interleaved_inodes }}
+        CVMFS_NFS_SHARED: ${{ inputs.cvmfs_nfs_shared }}
+        CVMFS_NFS_SOURCE: ${{ inputs.cvmfs_nfs_source }}
+        CVMFS_OOM_SCORE_ADJ: ${{ inputs.cvmfs_oom_score_adj }}
+        CVMFS_PAC_URLS: ${{ inputs.cvmfs_pac_urls }}
+        CVMFS_PROXY_RESET_AFTER: ${{ inputs.cvmfs_proxy_reset_after }}
+        CVMFS_PROXY_TEMPLATE: ${{ inputs.cvmfs_proxy_template }}
+        CVMFS_PUBLIC_KEY: ${{ inputs.cvmfs_public_key }}
+        CVMFS_QUOTA_LIMIT: ${{ inputs.cvmfs_quota_limit }}
+        CVMFS_RELOAD_SOCKETS: ${{ inputs.cvmfs_reload_sockets }}
+        CVMFS_REPOSITORIES: ${{ inputs.cvmfs_repositories }}
+        CVMFS_REPOSITORY_DATE: ${{ inputs.cvmfs_repository_date }}
+        CVMFS_REPOSITORY_TAG: ${{ inputs.cvmfs_repository_tag }}
+        CVMFS_ROOT_HASH: ${{ inputs.cvmfs_root_hash }}
+        CVMFS_SEND_INFO_HEADER: ${{ inputs.cvmfs_send_info_header }}
+        CVMFS_SERVER_CACHE_MODE: ${{ inputs.cvmfs_server_cache_mode }}
+        CVMFS_SERVER_URL: ${{ inputs.cvmfs_server_url }}
+        CVMFS_SHARED_CACHE: ${{ inputs.cvmfs_shared_cache }}
+        CVMFS_STRICT_MOUNT: ${{ inputs.cvmfs_strict_mount }}
+        CVMFS_SUID: ${{ inputs.cvmfs_suid }}
+        CVMFS_SYSLOG_FACILITY: ${{ inputs.cvmfs_syslog_facility }}
+        CVMFS_SYSLOG_LEVEL: ${{ inputs.cvmfs_syslog_level }}
+        CVMFS_SYSTEMD_NOKILL: ${{ inputs.cvmfs_systemd_nokill }}
+        CVMFS_TIMEOUT: ${{ inputs.cvmfs_timeout }}
+        CVMFS_TIMEOUT_DIRECT: ${{ inputs.cvmfs_timeout_direct }}
+        CVMFS_TRACEFILE: ${{ inputs.cvmfs_tracefile }}
+        CVMFS_USE_CDN: ${{ inputs.cvmfs_use_cdn }}
+        CVMFS_USE_GEOAPI: ${{ inputs.cvmfs_use_geoapi }}
+        CVMFS_USER: ${{ inputs.cvmfs_user }}
+        CVMFS_USYSLOG: ${{ inputs.cvmfs_usyslog }}
+        CVMFS_WORKSPACE: ${{ inputs.cvmfs_workspace }}
+        CVMFS_UBUNTU_DEB_LOCATION: ${{ inputs.cvmfs_ubuntu_deb_location }}
+        CVMFS_MACOS_PKG_LOCATION: ${{ inputs.cvmfs_macos_pkg_location }}
+        CVMFS_CONFIG_PACKAGE: ${{ inputs.cvmfs_config_package }}

--- a/action.yml
+++ b/action.yml
@@ -324,10 +324,20 @@ inputs:
     description: 'URL to the cvmfs config package to install'
     required: false
     default: 'cvmfs-config-default'
+  run_local_checkout:
+    description: 'Run the local checkout of the action and not the main repo code'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/setup-cvmfs.sh
+    - run: |
+        if [ "${{ inputs.run_local_checkout }}" == "true" ]; then
+          echo "WARNING running local checkout of the action !"
+          .  setup-cvmfs.sh local
+        else
+          ${{ github.action_path }}/setup-cvmfs.sh
+        fi
       shell: bash
       env:
         THIS: ${{ github.action_path }}

--- a/createConfig.sh
+++ b/createConfig.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+declare -a vars=(CVMFS_ALIEN_CACHE
+                 CVMFS_ALT_ROOT_PATH
+                 CVMFS_AUTHZ_HELPER
+                 CVMFS_AUTHZ_SEARCH_PATH
+                 CVMFS_AUTO_UPDATE
+                 CVMFS_BACKOFF_INIT
+                 CVMFS_BACKOFF_MAX
+                 CVMFS_CACHE_BASE
+                 CVMFS_CATALOG_WATERMARK
+                 CVMFS_CHECK_PERMISSIONS
+                 CVMFS_CLAIM_OWNERSHIP
+                 CVMFS_CLIENT_PROFILE
+                 CVMFS_CONFIG_REPO_REQUIRED
+                 CVMFS_DEBUGLOG
+                 CVMFS_DEFAULT_DOMAIN
+                 CVMFS_DNS_MAX_TTL
+                 CVMFS_DNS_MIN_TTL
+                 CVMFS_DNS_RETRIES
+                 CVMFS_DNS_ROAMING
+                 CVMFS_DNS_TIMEOUT
+                 CVMFS_ENFORCE_ACLS
+                 CVMFS_EXTERNAL_FALLBACK_PROXY
+                 CVMFS_EXTERNAL_HTTP_PROXY
+                 CVMFS_EXTERNAL_TIMEOUT
+                 CVMFS_EXTERNAL_TIMEOUT_DIRECT
+                 CVMFS_EXTERNAL_URL
+                 CVMFS_FALLBACK_PROXY
+                 CVMFS_FOLLOW_REDIRECTS
+                 CVMFS_HIDE_MAGIC_XATTRS
+                 CVMFS_HOST_RESET_AFTER
+                 CVMFS_HTTP_PROXY
+                 CVMFS_IGNORE_SIGNATURE
+                 CVMFS_INITIAL_GENERATION
+                 CVMFS_INSTRUMENT_FUSE
+                 CVMFS_IPFAMILY_PREFER
+                 CVMFS_KCACHE_TIMEOUT
+                 CVMFS_KEYS_DIR
+                 CVMFS_LOW_SPEED_LIMIT
+                 CVMFS_MAX_EXTERNAL_SERVERS
+                 CVMFS_MAX_IPADDR_PER_PROXY
+                 CVMFS_MAX_RETRIES
+                 CVMFS_MAX_SERVERS
+                 CVMFS_MAX_TTL
+                 CVMFS_MEMCACHE_SIZE
+                 CVMFS_MOUNT_RW
+                 CVMFS_NFILES
+                 CVMFS_NFS_INTERLEAVED_INODES
+                 CVMFS_NFS_SHARED
+                 CVMFS_NFS_SOURCE
+                 CVMFS_OOM_SCORE_ADJ
+                 CVMFS_PAC_URLS
+                 CVMFS_PROXY_RESET_AFTER
+                 CVMFS_PROXY_TEMPLATE
+                 CVMFS_PUBLIC_KEY
+                 CVMFS_QUOTA_LIMIT
+                 CVMFS_RELOAD_SOCKETS
+                 CVMFS_REPOSITORIES
+                 CVMFS_REPOSITORY_DATE
+                 CVMFS_REPOSITORY_TAG
+                 CVMFS_ROOT_HASH
+                 CVMFS_SEND_INFO_HEADER
+                 CVMFS_SERVER_CACHE_MODE
+                 CVMFS_SERVER_URL
+                 CVMFS_SHARED_CACHE
+                 CVMFS_STRICT_MOUNT
+                 CVMFS_SUID
+                 CVMFS_SYSLOG_FACILITY
+                 CVMFS_SYSLOG_LEVEL
+                 CVMFS_SYSTEMD_NOKILL
+                 CVMFS_TIMEOUT
+                 CVMFS_TIMEOUT_DIRECT
+                 CVMFS_TRACEFILE
+                 CVMFS_USE_CDN
+                 CVMFS_USE_GEOAPI
+                 CVMFS_USER
+                 CVMFS_USYSLOG
+                 CVMFS_WORKSPACE
+)
+
+sudo mkdir -p /etc/cvmfs
+echo "# cvmfs default.local file installed with cvmfs-contrib/github-action-cvmfs" | sudo tee /etc/cvmfs/default.local
+for var_name in "${vars[@]}"
+do
+  if [ ! -z "$(eval "echo \$$var_name")" ]; then
+    echo "$var_name='$(eval "echo \$$var_name")'" | sudo tee -a /etc/cvmfs/default.local
+  fi
+done

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -32,6 +32,8 @@ if [ "$1" == "local" ]; then
 else
   $THIS/createConfig.sh
 fi
+
+echo "Run cvmfs_config setup"
 sudo cvmfs_config setup
 
 

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -27,7 +27,11 @@ else
   exit 1
 fi
 
-$THIS/createConfig.sh
+if [ "$1" == "local" ]; then
+  . createConfig.sh
+else
+  $THIS/createConfig.sh
+fi
 sudo cvmfs_config setup
 
 


### PR DESCRIPTION
- This extends the the action to work on macOS with the limitions to mount the repository under `/User/share`
- Maps all variables from [Client Parameters](https://cvmfs.readthedocs.io/en/stable/apx-parameters.html#client-parameters) to same name github action parameters
- All default paramers are in the action and none in the scripts
- The default.local how by default only `CVMFS_CLIENT_PROFILE='signle'` and `CVMFS_USE_CDN='yes'` as `CVMFS_HTTP_PROXY` is implied by `CVMFS_USE_CDN`

I am still having problem to configure that the testing would work for PRs but
```diff
- uses: cvmfs-contrib/github-action-cvmfs@main
+ uses: ${{ github.repository }}@main
```

But does not want. So there is a bit of work here still