### PR TITLE
Check return code cvmfs_config at the end of installation

### DIFF
--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -35,6 +35,12 @@ fi
 
 echo "Run cvmfs_config setup"
 sudo cvmfs_config setup
+retCongif=$?
+if [ $retCongif -ne 0 ]; then
+  echo "!!! github-action-cvmfs FAILED !!!"
+  echo "cvmfs_config setup exited with ${retCongif}"
+  exit $retCongif
+fi
 
 
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
The return code of `cmvfs_config setup` should be checked in the action as it is not the last command in the `setup-cvmfs.sh` script.