### PR TITLE
Update deprecated brew behaviour

### DIFF
--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -19,7 +19,7 @@ elif [ "$(uname)" == "Darwin" ]; then
   if [ -z "${CVMFS_HTTP_PROXY}" ]; then
     export CVMFS_HTTP_PROXY='DIRECT'
   fi
-  brew cask install osxfuse
+  brew install --cask osxfuse
   curl -L -o cvmfs-latest.pkg ${CVMFS_MACOS_PKG_LOCATION}
   sudo installer -package cvmfs-latest.pkg -target /
 else


### PR DESCRIPTION
`brew cask install osxfuse` does not work anymore and need to be replaced with `brew install --cask osxfuse`