### PR TITLE
Use `brew install --cask`

### DIFF
--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -19,7 +19,7 @@ elif [ "$(uname)" == "Darwin" ]; then
   if [ -z "${CVMFS_HTTP_PROXY}" ]; then
     export CVMFS_HTTP_PROXY='DIRECT'
   fi
-  brew cask install osxfuse
+  brew install --cask osxfuse
   curl -L -o cvmfs-latest.pkg ${CVMFS_MACOS_PKG_LOCATION}
   sudo installer -package cvmfs-latest.pkg -target /
 else


### PR DESCRIPTION
`brew cask install` has been deprecated in 2.6.0 and removed in 2.7.0. See https://brew.sh/2020/12/01/homebrew-2.6.0/ and Homebrew/brew/pull/8899