### PR TITLE
change osxfuse for macfuse

### DIFF
--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -19,7 +19,7 @@ elif [ "$(uname)" == "Darwin" ]; then
   if [ -z "${CVMFS_HTTP_PROXY}" ]; then
     export CVMFS_HTTP_PROXY='DIRECT'
   fi
-  brew install --cask osxfuse
+  brew install --cask macfuse
   curl -L -o cvmfs-latest.pkg ${CVMFS_MACOS_PKG_LOCATION}
   sudo installer -package cvmfs-latest.pkg -target /
 else


### PR DESCRIPTION
With cvmfs 2.8.0 there is a need for a newer version of fuse, however osxfuse was renamed to macfuse, so if you do
```
brew install --cask osxfuse
```
you get version 3.11, but you need version 4.0, for which you need to call
```
brew install --cask macfuse
```

@vvolkl it's re-tag time again