### PR TITLE
Run workflows MacOS and Ubuntu daily

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,9 @@
 name: macOS
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '33 3 * * *'
 jobs:
   macOS-minimal:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,7 @@ jobs:
   macOS-minimal:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, macos-10.15, macos-11]
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-18.04, ubuntu-20.04]
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,5 +1,9 @@
 name: ubuntu
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '44 4 * * *'
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
To catch breaking changes to the underlying platforms (e.g. https://github.com/cvmfs/cvmfs/issues/2882), run the testing workflow daily.