### PR TITLE
feat: add group/endgroup for time analysis

### DIFF
--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -2,10 +2,16 @@
 
 #Platform specific install
 if [ "$(uname)" == "Linux" ]; then
+  echo "::group::curl and dpkg latest cvmfs release"
   curl -L -o cvmfs-release-latest_all.deb ${CVMFS_UBUNTU_DEB_LOCATION}
   sudo dpkg -i cvmfs-release-latest_all.deb
+  echo "::endgroup::"
+  echo "::group::apt-get update"
   sudo apt-get -q update
+  echo "::endgroup::"
+  echo "::group::apt-get install"
   sudo apt-get -q -y install cvmfs
+  echo "::endgroup::"
   rm -f cvmfs-release-latest_all.deb
   if [ "${CVMFS_CONFIG_PACKAGE}" == "cvmfs-config-default" ]; then
     sudo apt-get -q -y install cvmfs-config-default


### PR DESCRIPTION
I was intending this to be a PR to my own main, but whatever...

This would add some more info in the logs on how long the various dpkg, apt-get update, and apt-get install steps take. The idea is that there may be benefits from adding some caching support in this action if there are benefits, time-wise.