### PR TITLE
Warn about upcoming MacOS phase out

### DIFF
--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -15,6 +15,10 @@ if [ "$(uname)" == "Linux" ]; then
     rm -f cvmfs-config.deb
   fi
 elif [ "$(uname)" == "Darwin" ]; then
+  # Warn about the phasing out of MacOS support for this action
+  echo "::warning::The CernVM-FS GitHub Action's support for MacOS will be
+    phased out with macos-10.15, which will be unsupported by GitHub by 8/30/22.
+    See https://github.com/cvmfs-contrib/github-action-cvmfs/pull/17 for details."
   # Temporary fix for macOS until cvmfs 2.8 is released
   if [ -z "${CVMFS_HTTP_PROXY}" ]; then
     export CVMFS_HTTP_PROXY='DIRECT'

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -16,9 +16,9 @@ if [ "$(uname)" == "Linux" ]; then
   fi
 elif [ "$(uname)" == "Darwin" ]; then
   # Warn about the phasing out of MacOS support for this action
-  echo "::warning::The CernVM-FS GitHub Action's support for MacOS will be
-    phased out with macos-10.15, which will be unsupported by GitHub by 8/30/22.
-    See https://github.com/cvmfs-contrib/github-action-cvmfs/pull/17 for details."
+  echo "::warning::The CernVM-FS GitHub Action's support for MacOS will be \
+phased out with macos-10.15, which will be unsupported by GitHub by 8/30/22. \
+See https://github.com/cvmfs-contrib/github-action-cvmfs/pull/17 for details."
   # Temporary fix for macOS until cvmfs 2.8 is released
   if [ -z "${CVMFS_HTTP_PROXY}" ]; then
     export CVMFS_HTTP_PROXY='DIRECT'


### PR DESCRIPTION
This adds a warning for users of this action to let them know that MacOS support will disappear with the end of life of macos-10.15 in GitHub Actions in a month from now.

The idea is to merge this warning and retag v2 with these changes to ensure people see the warning.

Changes cherry-picked from #17.