### PR TITLE
Use current directory for action workflow

### DIFF
--- a/.github/workflows/cvmfs_config_package.yml
+++ b/.github/workflows/cvmfs_config_package.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: .
+    - uses: ./
       with:
         cvmfs_repositories: 'pilot.eessi-hpc.org'
         cvmfs_http_proxy: 'DIRECT'

--- a/.github/workflows/cvmfs_config_package.yml
+++ b/.github/workflows/cvmfs_config_package.yml
@@ -5,12 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@main
+    - uses: .
       with:
         cvmfs_repositories: 'pilot.eessi-hpc.org'
         cvmfs_http_proxy: 'DIRECT'
         cvmfs_config_package: 'https://github.com/EESSI/filesystem-layer/releases/download/v0.4.0/cvmfs-config-eessi_0.4.0_all.deb'
-        run_local_checkout: 'true'
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/.github/workflows/cvmfs_http_proxy.yml
+++ b/.github/workflows/cvmfs_http_proxy.yml
@@ -5,10 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@main
+    - uses: .
       with:
         cvmfs_http_proxy: 'auto'
-        run_local_checkout: 'true'
     - name: Setup CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/.github/workflows/cvmfs_http_proxy.yml
+++ b/.github/workflows/cvmfs_http_proxy.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: .
+    - uses: ./
       with:
         cvmfs_http_proxy: 'auto'
     - name: Setup CernVM-FS

--- a/.github/workflows/cvmfs_repositories.yml
+++ b/.github/workflows/cvmfs_repositories.yml
@@ -5,10 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@main
+    - uses: .
       with:
         cvmfs_repositories: 'grid.cern.ch'
-        run_local_checkout: 'true'
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/.github/workflows/cvmfs_repositories.yml
+++ b/.github/workflows/cvmfs_repositories.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: .
+    - uses: ./
       with:
         cvmfs_repositories: 'grid.cern.ch'
     - name: Test CernVM-FS

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,10 +13,9 @@ jobs:
         os: [macos-latest, macos-10.15, macos-11]
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@main
+    - uses: .
       with:
         cvmfs_repositories: 'sft.cern.ch'
-        run_local_checkout: 'true'
     - name: Test CernVM-FS
       run: |
        echo "### Dump default.local ###"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
         os: [macos-latest, macos-10.15, macos-11]
     steps:
     - uses: actions/checkout@v2
-    - uses: .
+    - uses: ./
       with:
         cvmfs_repositories: 'sft.cern.ch'
     - name: Test CernVM-FS

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,9 +13,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@main
-      with:
-        run_local_checkout: 'true'
+    - uses: .
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
-    - uses: .
+    - uses: ./
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/action.yml
+++ b/action.yml
@@ -332,12 +332,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-        if [ "${{ inputs.run_local_checkout }}" == "true" ]; then
-          echo "WARNING running local checkout of the action !"
-          .  setup-cvmfs.sh local
-        else
-          ${{ github.action_path }}/setup-cvmfs.sh
-        fi
+        ${{ github.action_path }}/setup-cvmfs.sh
       shell: bash
       env:
         THIS: ${{ github.action_path }}

--- a/action.yml
+++ b/action.yml
@@ -335,7 +335,7 @@ runs:
         ${{ github.action_path }}/setup-cvmfs.sh
       shell: bash
       env:
-        THIS: ${{ github.action_path }}
+        ACTION_PATH: ${{ github.action_path }}
         CVMFS_ALIEN_CACHE: ${{ inputs.cvmfs_alien_cache }}
         CVMFS_ALT_ROOT_PATH: ${{ inputs.cvmfs_alt_root_path }}
         CVMFS_AUTHZ_HELPER: ${{ inputs.cvmfs_authz_helper }}

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -27,11 +27,7 @@ else
   exit 1
 fi
 
-if [ "$1" == "local" ]; then
-  . createConfig.sh
-else
-  $THIS/createConfig.sh
-fi
+${ACTION_PATH}/createConfig.sh
 
 echo "Run cvmfs_config setup"
 sudo cvmfs_config setup


### PR DESCRIPTION
Previously we were using an option `run_local_checkout` instead of `action/checkout` followed by `uses: .`. The latter requires fewer branches and is more robust.