### PR TITLE
Use action/cache for apt downloads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -344,6 +344,11 @@ runs:
         echo "::set-output name=description::${DISTRIB_DESCRIPTION}"
         echo "::set-output name=id-release::${DISTRIB_ID}-${DISTRIB_DESCRIPTION}"
       shell: bash
+    - uses: actions/cache@v3
+      with:
+        key: cvmfs-apt-cache-${{ steps.lsb-release.outputs.id-release }}-${{ hashFiles('action.yml') }}
+        path: |
+          ${{ inputs.apt_cache }}
     - run: |
         ${{ github.action_path }}/setup-cvmfs.sh
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: 'folder'
   color: 'orange'
 inputs:
+  apt_cache:
+    description: 'Location (directory) of the user-space apt cache.'
+    required: false
+    default: '~/.apt'
   cvmfs_alien_cache:
     description: 'If set, use an alien cache at the given location.'
     required: false
@@ -336,6 +340,7 @@ runs:
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
+        APT_CACHE: ${{ inputs.apt_cache }}
         CVMFS_ALIEN_CACHE: ${{ inputs.cvmfs_alien_cache }}
         CVMFS_ALT_ROOT_PATH: ${{ inputs.cvmfs_alt_root_path }}
         CVMFS_AUTHZ_HELPER: ${{ inputs.cvmfs_authz_helper }}

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   apt_cache:
     description: 'Location (directory) of the user-space apt cache.'
     required: false
-    default: '~/.apt'
+    default: 'apt_cache'
   cvmfs_alien_cache:
     description: 'If set, use an alien cache at the given location.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -335,6 +335,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - id: lsb-release
+      run: |
+        source /etc/lsb-release
+        echo "::set-output name=id::${DISTRIB_ID}"
+        echo "::set-output name=release::${DISTRIB_RELEASE}"
+        echo "::set-output name=codename::${DISTRIB_CODENAME}"
+        echo "::set-output name=description::${DISTRIB_DESCRIPTION}"
+        echo "::set-output name=id-release::${DISTRIB_ID}-${DISTRIB_DESCRIPTION}"
+      shell: bash
     - run: |
         ${{ github.action_path }}/setup-cvmfs.sh
       shell: bash

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -26,6 +26,7 @@ if [ "$(uname)" == "Linux" ]; then
   fi
   # update cache (avoid restricted partial directories)
   if [ -n "${APT_CACHE}" ]; then
+    mkdir -p ${APT_CACHE}/archives/ ${APT_CACHE}/lists/
     cp /var/cache/apt/archives/*.deb ${APT_CACHE}/archives/
     cp /var/lib/apt/lists/*_dists_* ${APT_CACHE}/lists/
   fi

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -6,13 +6,11 @@ if [ "$(uname)" == "Linux" ]; then
   sudo dpkg -i cvmfs-release-latest_all.deb
   sudo apt-get -q update
   sudo apt-get -q -y install cvmfs
-  rm -f cvmfs-release-latest_all.deb
   if [ "${CVMFS_CONFIG_PACKAGE}" == "cvmfs-config-default" ]; then
     sudo apt-get -q -y install cvmfs-config-default
   else
     curl -L -o cvmfs-config.deb ${CVMFS_CONFIG_PACKAGE}
     sudo dpkg -i cvmfs-config.deb
-    rm -f cvmfs-config.deb
   fi
 elif [ "$(uname)" == "Darwin" ]; then
   # Warn about the phasing out of MacOS support for this action

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -2,6 +2,12 @@
 
 # Platform specific install
 if [ "$(uname)" == "Linux" ]; then
+  # download from cache
+  if [ -n "${APT_CACHE}" ]; then
+    mkdir -p ${APT_CACHE}/archives/ ${APT_CACHE}/lists/
+    sudo cp -r ${APT_CACHE}/archives /var/cache/apt
+    sudo cp -r ${APT_CACHE}/lists /var/lib/apt
+  fi
   # install cvmfs release package
   APT_ARCHIVES=/var/cache/apt/archives/
   if [ ! -f ${APT_ARCHIVES}/cvmfs-release-latest_all.deb ] ; then
@@ -18,6 +24,9 @@ if [ "$(uname)" == "Linux" ]; then
     sudo curl -L -o ${APT_ARCHIVES}/cvmfs-config.deb ${CVMFS_CONFIG_PACKAGE}
     sudo dpkg -i ${APT_ARCHIVES}/cvmfs-config.deb
   fi
+  # update cache (avoid restricted partial directories)
+  cp /var/cache/apt/archives/*.deb ${APT_CACHE}/archives/
+  cp /var/lib/apt/lists/*_dists_* ${APT_CACHE}/lists/
 elif [ "$(uname)" == "Darwin" ]; then
   # Warn about the phasing out of MacOS support for this action
   echo "::warning::The CernVM-FS GitHub Action's support for MacOS will be \

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -4,6 +4,7 @@
 if [ "$(uname)" == "Linux" ]; then
   # download from cache
   if [ -n "${APT_CACHE}" ]; then
+    echo "Copying cache from ${APT_CACHE} to system locations..."
     mkdir -p ${APT_CACHE}/archives/ ${APT_CACHE}/lists/
     sudo cp -r ${APT_CACHE}/archives /var/cache/apt
     sudo cp -r ${APT_CACHE}/lists /var/lib/apt
@@ -26,6 +27,7 @@ if [ "$(uname)" == "Linux" ]; then
   fi
   # update cache (avoid restricted partial directories)
   if [ -n "${APT_CACHE}" ]; then
+    echo "Copying cache from system locations to ${APT_CACHE}..."
     mkdir -p ${APT_CACHE}/archives/ ${APT_CACHE}/lists/
     cp /var/cache/apt/archives/*.deb ${APT_CACHE}/archives/
     cp /var/lib/apt/lists/*_dists_* ${APT_CACHE}/lists/

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 
-#Platform specific install
+# Platform specific install
 if [ "$(uname)" == "Linux" ]; then
-  curl -L -o cvmfs-release-latest_all.deb ${CVMFS_UBUNTU_DEB_LOCATION}
-  sudo dpkg -i cvmfs-release-latest_all.deb
+  # install cvmfs release package
+  APT_ARCHIVES=/var/cache/apt/archives/
+  if [ ! -f ${APT_ARCHIVES}/cvmfs-release-latest_all.deb ] ; then
+    sudo curl -L -o ${APT_ARCHIVES}/cvmfs-release-latest_all.deb ${CVMFS_UBUNTU_DEB_LOCATION}
+  fi
+  sudo dpkg -i ${APT_ARCHIVES}/cvmfs-release-latest_all.deb
+  # install cvmfs package
   sudo apt-get -q update
   sudo apt-get -q -y install cvmfs
+  # install cvmfs config package
   if [ "${CVMFS_CONFIG_PACKAGE}" == "cvmfs-config-default" ]; then
     sudo apt-get -q -y install cvmfs-config-default
   else
-    curl -L -o cvmfs-config.deb ${CVMFS_CONFIG_PACKAGE}
-    sudo dpkg -i cvmfs-config.deb
+    sudo curl -L -o ${APT_ARCHIVES}/cvmfs-config.deb ${CVMFS_CONFIG_PACKAGE}
+    sudo dpkg -i ${APT_ARCHIVES}/cvmfs-config.deb
   fi
 elif [ "$(uname)" == "Darwin" ]; then
   # Warn about the phasing out of MacOS support for this action

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -25,8 +25,10 @@ if [ "$(uname)" == "Linux" ]; then
     sudo dpkg -i ${APT_ARCHIVES}/cvmfs-config.deb
   fi
   # update cache (avoid restricted partial directories)
-  cp /var/cache/apt/archives/*.deb ${APT_CACHE}/archives/
-  cp /var/lib/apt/lists/*_dists_* ${APT_CACHE}/lists/
+  if [ -n "${APT_CACHE}" ]; then
+    cp /var/cache/apt/archives/*.deb ${APT_CACHE}/archives/
+    cp /var/lib/apt/lists/*_dists_* ${APT_CACHE}/lists/
+  fi
 elif [ "$(uname)" == "Darwin" ]; then
   # Warn about the phasing out of MacOS support for this action
   echo "::warning::The CernVM-FS GitHub Action's support for MacOS will be \


### PR DESCRIPTION
This uses action/cache for apt downloads (*.deb and lists) to prevent hitting CERN apt repo locations frequently with download requests.