### PR TITLE
fix: replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -340,7 +340,7 @@ runs:
         source /etc/lsb-release
         echo "id=${DISTRIB_ID}" >> $GITHUB_OUTPUT
         echo "release=${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
-        echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUTENV
+        echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUT
         echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
         echo "id-release=${DISTRIB_ID}-${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -338,11 +338,11 @@ runs:
     - id: lsb-release
       run: |
         source /etc/lsb-release
-        echo "::set-output name=id::${DISTRIB_ID}"
-        echo "::set-output name=release::${DISTRIB_RELEASE}"
-        echo "::set-output name=codename::${DISTRIB_CODENAME}"
-        echo "::set-output name=description::${DISTRIB_DESCRIPTION}"
-        echo "::set-output name=id-release::${DISTRIB_ID}-${DISTRIB_DESCRIPTION}"
+        echo "id=${DISTRIB_ID}" >> $GITHUB_OUTPUT
+        echo "release=${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
+        echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUTENV
+        echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
+        echo "id-release=${DISTRIB_ID}-${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
       shell: bash
     - uses: actions/cache@v3
       with:


### PR DESCRIPTION
"Starting today runner version 2.298.2 will begin to warn you if you use the save-state or set-output commands via stdout." [GitHub blog, 2022-10-11](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

And wouldn't you know it... All my jobs warning endlessly!

This modifies the `lsb-release` step to use the new way of providing outputs.