### PR TITLE
ci(chore): upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/cvmfs_config_package.yml
+++ b/.github/workflows/cvmfs_config_package.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         cvmfs_repositories: 'pilot.eessi-hpc.org'

--- a/.github/workflows/cvmfs_http_proxy.yml
+++ b/.github/workflows/cvmfs_http_proxy.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         cvmfs_http_proxy: 'auto'

--- a/.github/workflows/cvmfs_repositories.yml
+++ b/.github/workflows/cvmfs_repositories.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         cvmfs_repositories: 'grid.cern.ch'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
     - name: Test CernVM-FS
       run: |


### PR DESCRIPTION
This is more than just a chore in that GitHub has been starting to generate warnings about actions/checkout@v2.

"Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout"