### PR TITLE
ci(chore): replace ubuntu-18.04 with ubuntu-22.04

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-latest, ubuntu-20.04, ubuntu-22.04]
     steps:
     - uses: actions/checkout@v2
     - uses: ./


### PR DESCRIPTION
The ubuntu-18.04 is being deprecated and emitting warnings.

"The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002."