### PR TITLE
fix: update actions/cache from v3 to v4 (node.js v20 support)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -344,7 +344,7 @@ runs:
         echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
         echo "id-release=${DISTRIB_ID}-${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
       shell: bash
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         key: cvmfs-apt-cache-${{ steps.lsb-release.outputs.id-release }}-${{ hashFiles('action.yml') }}
         path: |


### PR DESCRIPTION
The warnings [promised](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.) for October 23 have finally arrived. This updates the underlying actions/cache from v3 to v4.