### PR TITLE
feat: enable dependabot for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR enable dependabot on this repository so underlying dependency updates are caught. This won't update the action.yml, but it will generate updates to the tests in .github/workflow, so can hope we get at least some indication of when updates are needed. Not sure there's a way to get updates to action.yml...