### PR TITLE
Re-enable experimental support for cvmfs on macos runners

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,6 @@ jobs:
         os: [macos-latest, macos-11]
     steps:
     - uses: actions/checkout@v2
-    - uses: Homebrew/actions/setup-homebrew@master
     - uses: ./
       with:
         cvmfs_repositories: 'sft.cern.ch'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,27 @@
+name: macOS
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '33 3 * * *'
+jobs:
+  macOS-minimal:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-11]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Homebrew/actions/setup-homebrew@master
+    - uses: ./
+      with:
+        cvmfs_repositories: 'sft.cern.ch'
+    - name: Test CernVM-FS
+      run: |
+       echo "### Dump default.local ###"
+       cat /etc/cvmfs/default.local
+       echo "### Try to ls on /Users/Shared/cvmfs/sft.cern.ch/ ###"
+       ls /Users/Shared/cvmfs/sft.cern.ch/
+       echo "### Try to ls on /cvmfs/sft.cern.ch/ ###"
+       ls /cvmfs/sft.cern.ch/

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This GitHub Action installs the [CernVM-FS package](https://cernvm.cern.ch/fs/#d
 
 ## Limitations
 
-This GitHub Action is only expected to work in workflows that [run on](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on) ubuntu. There is experimental support for `macOS`.
+This GitHub Action is only expected to work in workflows that [run on](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on) ubuntu. There is experimental support for `macOS` (11+).
 
  `windows` targets are not supported.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ This GitHub Action installs the [CernVM-FS package](https://cernvm.cern.ch/fs/#d
 
 ## Limitations
 
-This GitHub Action is only expected to work in workflows that [run on](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on) ubuntu. This exludes the `macos` and `windows` targets.
+This GitHub Action is only expected to work in workflows that [run on](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on) ubuntu. There is experimental support for `macOS`.
+
+ `windows` targets are not supported.
 
 ## Use With Docker
 

--- a/action.yml
+++ b/action.yml
@@ -347,6 +347,8 @@ runs:
           echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUT
           echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
           echo "id-release=${DISTRIB_ID}-${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          echo "id-release=macOS-$(sw_vers -productVersion)" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - uses: actions/cache@v4

--- a/action.yml
+++ b/action.yml
@@ -323,7 +323,10 @@ inputs:
   cvmfs_macos_pkg_location:
     description: 'Location from where to download the masOS pkg package of CernVM-FS'
     required: false
-    default: 'http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-latest.pkg'
+    #default: 'http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-latest.pkg'
+    # this nightly build is based on the cvmfs mac-fuse-t branch
+    # TODO: change back to latest once it is released
+    default: 'http://ecsft.cern.ch/dist/cvmfs/nightlies/cvmfs-git-1234/cvmfs-2.12.0-0.1234-git-958741c6df468802.pkg'
   cvmfs_config_package:
     description: 'URL to the cvmfs config package to install'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -340,12 +340,14 @@ runs:
   steps:
     - id: lsb-release
       run: |
-        source /etc/lsb-release
-        echo "id=${DISTRIB_ID}" >> $GITHUB_OUTPUT
-        echo "release=${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
-        echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUT
-        echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
-        echo "id-release=${DISTRIB_ID}-${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          source /etc/lsb-release
+          echo "id=${DISTRIB_ID}" >> $GITHUB_OUTPUT
+          echo "release=${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
+          echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUT
+          echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
+          echo "id-release=${DISTRIB_ID}-${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
+        fi
       shell: bash
     - uses: actions/cache@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -321,7 +321,7 @@ inputs:
     required: false
     default: 'https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb'
   cvmfs_macos_pkg_location:
-    description: 'Location from where to download the masOS pkg package of CernVM-FS'
+    description: 'Location from where to download the macOS pkg package of CernVM-FS'
     required: false
     #default: 'http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-latest.pkg'
     # this nightly build is based on the cvmfs mac-fuse-t branch

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -42,15 +42,22 @@ if [ "$(uname)" == "Linux" ]; then
   fi
 elif [ "$(uname)" == "Darwin" ]; then
   # Warn about the phasing out of MacOS support for this action
-  echo "::error::The CernVM-FS GitHub Action's support for MacOS has been \
-phased out with macos-10.15."
+  echo "warning The CernVM-FS GitHub Action's support for MacOS  \
+        is still experimental."
   # Temporary fix for macOS until cvmfs 2.8 is released
   if [ -z "${CVMFS_HTTP_PROXY}" ]; then
     export CVMFS_HTTP_PROXY='DIRECT'
   fi
-  brew install --cask macfuse
+  brew tap macos-fuse-t/homebrew-cask
+  brew install fuse-t
   curl -L -o cvmfs-latest.pkg ${CVMFS_MACOS_PKG_LOCATION}
   sudo installer -package cvmfs-latest.pkg -target /
+  # / is readonly on macos 11+ - do 'synthetic firmlink' to create /cvmfs
+  sudo zsh -c 'echo -e "cvmfs\tUsers/Shared/cvmfs\n#comment\n" > /etc/synthetic.conf'
+  sudo chown root:wheel /etc/synthetic.conf
+  sudo chmod a+r /etc/synthetic.conf
+  # apfs.util seems to return non-zero error codes also on success
+  sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t || true
 else
   echo "Unsupported platform"
   exit 1

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -48,8 +48,10 @@ elif [ "$(uname)" == "Darwin" ]; then
   if [ -z "${CVMFS_HTTP_PROXY}" ]; then
     export CVMFS_HTTP_PROXY='DIRECT'
   fi
-  brew tap macos-fuse-t/homebrew-cask
-  brew install fuse-t
+
+  wget -q https://github.com/macos-fuse-t/fuse-t/releases/download/1.0.36/fuse-t-macos-installer-1.0.36.pkg
+  sudo installer -pkg fuse-t-macos-installer-1.0.36.pkg -target /
+
   curl -L -o cvmfs-latest.pkg ${CVMFS_MACOS_PKG_LOCATION}
   sudo installer -package cvmfs-latest.pkg -target /
   # / is readonly on macos 11+ - do 'synthetic firmlink' to create /cvmfs


### PR DESCRIPTION
While macfuse is no longer an option, there is now a nice alternative with fuse-t. This PR adds experimental support (I've successfully tested it with the nightly build, but there is no released cvmfs version with fuse-t support yet). @YBelikov may be able to add it in the context of a GSoC project.

'Synthetic firmlinks' are used to create /cvmfs , since the root file system is now read-only on macos.

One todo: need to check if we actually need the homebrew action or it can be moved somewhere else.