### PR TITLE
Make cvmfs_http_proxy default to DIRECT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -129,9 +129,9 @@ inputs:
     required: false
     default: ''
   cvmfs_http_proxy:
-    description: 'Chain of HTTP proxy groups used by CernVM-FS. Necessary.Set to DIRECT if you don’t use proxies.'
+    description: 'Chain of HTTP proxy groups used by CernVM-FS. Defaults to DIRECT.'
     required: false
-    default: ''
+    default: 'DIRECT'
   cvmfs_ignore_signature:
     description: 'When set to yes, don’t verify CernVM-FS file catalog signatures.'
     required: false

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -44,10 +44,6 @@ elif [ "$(uname)" == "Darwin" ]; then
   # Warn about the phasing out of MacOS support for this action
   echo "warning The CernVM-FS GitHub Action's support for MacOS  \
         is still experimental."
-  # Temporary fix for macOS until cvmfs 2.8 is released
-  if [ -z "${CVMFS_HTTP_PROXY}" ]; then
-    export CVMFS_HTTP_PROXY='DIRECT'
-  fi
 
   brew tap macos-fuse-t/cask
   brew tap cvmfs/homebrew-cvmfs


### PR DESCRIPTION
Since github actions are run in Azure where there is not normally a proxy defined, leaving cvmfs_http_proxy unset results in a call to WLCG Web Proxy Auto Discovery (WPAD).  If there are enough of them in a short period of time (125 requests within 15 minutes) from the one organization (as defined by Maxmind) then the WPAD directs clients to backup proxies, which causes an alarm.  That alarm was triggered yesterday.  This PR fixes that problem by defaulting cvmfs_http_proxy to DIRECT.

After merging I would like a new tag, and I will also backport to v4 where we'll need another tag.  The [specific action](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/main/.github/workflows/cvmfs-ci.yml#L28) that likely triggered the alarm was using v4.