### PR TITLE
Update macOS versions in workflow matrix

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-13]
+        os: [macos-latest, macos-14, macos-15]
     steps:
     - uses: actions/checkout@v6
     - uses: ./


### PR DESCRIPTION
Since macos-13 is now unavailable, this upgrades the macos workflows to use 14 and 15 explicitly (in addition to latest).