### PR TITLE
feat(ci): add ubuntu-slim to default test matrix

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-slim, ubuntu-latest, ubuntu-22.04, ubuntu-24.04]
     steps:
     - uses: actions/checkout@v6
     - uses: ./


### PR DESCRIPTION
This PR tentatively adds [`ubuntu-slim`](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) to the default test matrix.