### PR TITLE
update .deb download url for release package

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ All optional parameters are set by default to `''`(empty string). All variables 
  - `cvmfs_quota_limit`: `'15000'` (see [GitHub Runner Hardware](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources) before changing)
  - `cvmfs_client_profile`: `'single'`
  - `cvmfs_use_cdn`: `'yes'`
- - `cvmfs_ubuntu_deb_location`: `https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb`
+ - `cvmfs_ubuntu_deb_location`: `https://cvmrepo.s3.cern.ch/cvmrepo/apt/cvmfs-release-latest_all.deb`
  - `cvmfs_config_package`: `cvmfs-config-default`
 
 ## Minimal Example

--- a/action.yml
+++ b/action.yml
@@ -319,7 +319,7 @@ inputs:
   cvmfs_ubuntu_deb_location:
     description: 'Location from where to download the Ubuntu deb package of CernVM-FS'
     required: false
-    default: 'https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb'
+    default: 'https://cvmrepo.s3.cern.ch/cvmrepo/apt/cvmfs-release-latest_all.deb'
   cvmfs_config_package:
     description: 'URL to the cvmfs config package to install'
     required: false


### PR DESCRIPTION
Changing the url for the download of the release package to our s3 server. This is by far the most reliable one, and the package repository anyway uses that (with a fallback to cvmrepo.web.cern.ch, which is a mirror) so no need to introduce another point of failure. This is in line with the docs that already use this url in the quick start.