### PR TITLE
Caching of apt lists now opt-in (`apt_cache_full`)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Location (directory) of the user-space apt cache.'
     required: false
     default: 'apt_cache'
+  apt_cache_full:
+    description: 'If set to yes, cache APT package lists in addition to .deb packages. This speeds up the action, but may require manual intervention to clear the cache when gh actions runner images are updated'
+    required: false
+    default: 'no'
   cvmfs_alien_cache:
     description: 'If set, use an alien cache at the given location.'
     required: false
@@ -362,6 +366,7 @@ runs:
       env:
         ACTION_PATH: ${{ github.action_path }}
         APT_CACHE: ${{ inputs.apt_cache }}
+        APT_CACHE_LISTS: ${{ inputs.apt_cache_full }}
         CVMFS_ALIEN_CACHE: ${{ inputs.cvmfs_alien_cache }}
         CVMFS_ALT_ROOT_PATH: ${{ inputs.cvmfs_alt_root_path }}
         CVMFS_AUTHZ_HELPER: ${{ inputs.cvmfs_authz_helper }}

--- a/setup-cvmfs.sh
+++ b/setup-cvmfs.sh
@@ -6,9 +6,12 @@ if [ "$(uname)" == "Linux" ]; then
   if [ -n "${APT_CACHE}" ]; then
     echo "::group::Using cache"
     echo "Copying cache from ${APT_CACHE} to system locations..."
-    mkdir -p ${APT_CACHE}/archives/ ${APT_CACHE}/lists/
+    mkdir -p ${APT_CACHE}/archives/
     sudo cp -r ${APT_CACHE}/archives /var/cache/apt
-    sudo cp -r ${APT_CACHE}/lists /var/lib/apt
+    if [ "${APT_CACHE_LISTS}" == "yes" ]; then
+      mkdir -p ${APT_CACHE}/lists/
+      sudo cp -r ${APT_CACHE}/lists /var/lib/apt
+    fi
     echo "::endgroup::"
   fi
   # install cvmfs release package
@@ -37,9 +40,12 @@ if [ "$(uname)" == "Linux" ]; then
   if [ -n "${APT_CACHE}" ]; then
     echo "::group::Updating cache"
     echo "Copying cache from system locations to ${APT_CACHE}..."
-    mkdir -p ${APT_CACHE}/archives/ ${APT_CACHE}/lists/
+    mkdir -p ${APT_CACHE}/archives/
     cp /var/cache/apt/archives/*.deb ${APT_CACHE}/archives/
-    cp /var/lib/apt/lists/*_dists_* ${APT_CACHE}/lists/
+    if [ "${APT_CACHE_LISTS}" == "yes" ]; then
+      mkdir -p ${APT_CACHE}/lists/
+      cp /var/lib/apt/lists/*_dists_* ${APT_CACHE}/lists/
+    fi
     echo "::endgroup::"
   fi
 elif [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Since there are not-so-well understood apt install failures from time to time, a workaround is to cache only the .deb files not the lists. If people are aware of the problem and don't mind an occasional failure + manual cache clear, the can opt into caching the lists with the apt_cache_full parameter. To be seen how much this this costs in time of running apt update.

For the long term, I think it'll be best to use either the cvmfs service container or a dedicated statically linked binary for this action and not use apt at all, but that'll take a few months.