### PR TITLE
fix: update actions/cache@v5 to hash-pinned version (v5.0.5)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -355,7 +355,7 @@ runs:
         ACTION_OWNER=$(basename $(dirname $(dirname "$GITHUB_ACTION_PATH")))
         echo "cvmfs_action_version=${ACTION_OWNER}_${ACTION_NAME}_${ACTION_VERSION}" >> $GITHUB_OUTPUT
       shell: bash
-    - uses: actions/cache@v5
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
       with:
         key: cvmfs-apt-cache-${{ steps.lsb-release.outputs.id-release }}-${{ steps.lsb-release.outputs.arch }}-${{ steps.lsb-release.outputs.cvmfs_action_version }}
         path: |


### PR DESCRIPTION
This PR fixes #64 by pinning actions/cache to the commit hash instead of mutable tag. Ref: https://github.com/actions/cache/releases/tag/v5.0.5 for commit hash.